### PR TITLE
Fix cmakelists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -138,5 +138,6 @@ if (${BUILD_ROS})
 	target_link_libraries(ublox_ros UBLOX ${catkin_LIBRARIES})
     target_include_directories(ublox_ros PUBLIC ../../devel/include ${catkin_INCLUDE_DIRS})
     add_dependencies(ublox_ros ${catkin_EXPORTED_TARGETS})
+    add_dependencies(ublox_ros ublox_generate_messages_cpp)
 
 endif()


### PR DESCRIPTION
Comment out parts of cmakelists that were not cloning right. (i.e. gtest)

Rearrange the formatting to bring it up to date with catkin build.